### PR TITLE
Fixes for WP71

### DIFF
--- a/src/Caliburn.Micro.Autofac-WP7/AutofacBootstrapper.cs
+++ b/src/Caliburn.Micro.Autofac-WP7/AutofacBootstrapper.cs
@@ -125,9 +125,15 @@ namespace Caliburn.Micro.Autofac
       //builder.RegisterInstance<PhoneContainer>(this).InstancePerLifetimeScope();
       //builder.RegisterInstance<IPhoneContainer>(this).InstancePerLifetimeScope();
 
+      // The constructor of these services must be called
+      // to attach to the framework properly.
+      var phoneService = CreatePhoneApplicationServiceAdapter();
+      var navigationService = CreateFrameAdapter();
+
       //  register the singletons
-      builder.Register<INavigationService>(c => CreateFrameAdapter()).InstancePerLifetimeScope();
-      builder.Register<IPhoneService>(c => CreatePhoneApplicationServiceAdapter()).InstancePerLifetimeScope();
+      builder.Register<IPhoneContainer>(c => new AutofacPhoneContainer(c)).InstancePerLifetimeScope();
+      builder.RegisterInstance<INavigationService>(navigationService).SingleInstance();
+      builder.RegisterInstance<IPhoneService>(phoneService).SingleInstance();
       builder.Register<IEventAggregator>(c => CreateEventAggregator()).InstancePerLifetimeScope();
       builder.Register<IWindowManager>(c => CreateWindowManager()).InstancePerLifetimeScope();
       builder.Register<IVibrateController>(c => CreateVibrateController()).InstancePerLifetimeScope();

--- a/src/Caliburn.Micro.Autofac-WP7/AutofacPhoneContainer.cs
+++ b/src/Caliburn.Micro.Autofac-WP7/AutofacPhoneContainer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO.IsolatedStorage;
+using Autofac;
+
+namespace Caliburn.Micro.Autofac
+{
+  internal class AutofacPhoneContainer : IPhoneContainer
+  {
+    private readonly IComponentContext context;
+
+    public AutofacPhoneContainer(IComponentContext context)
+    {
+      this.context = context;
+    }
+
+    public event Action<object> Activated = _ => { };
+
+    public void RegisterWithAppSettings(Type service, string appSettingsKey, Type implementation)
+    {
+      if (!IsolatedStorageSettings.ApplicationSettings.Contains(appSettingsKey ?? service.FullName))
+      {
+        IsolatedStorageSettings.ApplicationSettings[appSettingsKey ?? service.FullName] = context.Resolve(implementation);
+      }
+
+      var builder = new ContainerBuilder();
+
+      builder.Register(c =>
+      {
+        if (IsolatedStorageSettings.ApplicationSettings.Contains(appSettingsKey ?? service.FullName))
+        {
+          return IsolatedStorageSettings.ApplicationSettings[appSettingsKey ?? service.FullName];
+        }
+
+        return c.Resolve(implementation);
+      }).Named(appSettingsKey, service);
+
+      builder.Update(context.ComponentRegistry);
+    }
+
+    public void RegisterWithPhoneService(Type service, string phoneStateKey, Type implementation)
+    {
+      var pservice = (IPhoneService)GetInstance(typeof(IPhoneService), null);
+
+      if (!pservice.State.ContainsKey(phoneStateKey ?? service.FullName))
+      {
+        pservice.State[phoneStateKey ?? service.FullName] = context.Resolve(implementation);
+      }
+
+      var builder = new ContainerBuilder();
+
+      builder.Register(c =>
+      {
+        var phoneService = c.Resolve<IPhoneService>();
+
+        if (phoneService.State.ContainsKey(phoneStateKey ?? service.FullName))
+        {
+          return phoneService.State[phoneStateKey ?? service.FullName];
+        }
+
+        return c.Resolve(implementation);
+      }).Named(phoneStateKey, service);
+
+      builder.Update(context.ComponentRegistry);
+    }
+
+    private object GetInstance(Type service, string key)
+    {
+      return string.IsNullOrEmpty(key) ? context.Resolve(service) : context.ResolveNamed(key, service);
+    }
+  }
+}

--- a/src/Caliburn.Micro.Autofac-WP7/Caliburn.Micro.Autofac-WP71.csproj
+++ b/src/Caliburn.Micro.Autofac-WP7/Caliburn.Micro.Autofac-WP71.csproj
@@ -71,6 +71,7 @@
       <Link>EventAggregationAutoSubscriptionModule.cs</Link>
     </Compile>
     <Compile Include="AutofacBootstrapper.cs" />
+    <Compile Include="AutofacPhoneContainer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
There are a few issues getting the bootstrapper to run under WP71. Caliburn.Micro assumes a few of the services have been created up front, which Autofac doesn't do by default.

See http://stackoverflow.com/a/8569021/3820 for a discussion.
