### PR TITLE
Updated to Caliburn.Micro 1.4

### DIFF
--- a/Caliburn.Micro.Autofac.nuspec
+++ b/Caliburn.Micro.Autofac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Caliburn.Micro.Autofac</id>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <title>Caliburn.Micro.Autofac</title>
     <authors>David Buksbaum</authors>
     <owners />
@@ -13,7 +13,7 @@
     <summary>Integration of Caliburn.Micro with Autofac. Source code with sample projects available at https://github.com/dbuksbaum/Caliburn.Micro.Autofac</summary>
     <tags>Caliburn.Micro Autofac IoC DI MVVM</tags>
     <dependencies>
-      <dependency id="Caliburn.Micro" version="1.3.1" />
+      <dependency id="Caliburn.Micro" version="1.4" />
       <dependency id="Autofac" version="2.6.1.841" />
     </dependencies>
   </metadata>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Source code to the [Caliburn.Micro.Autofac nuget package](http://nuget.org/List/
 - [Caliburn.Micro.Autofac](http://buksbaum.us/things-i-did/caliburn-micro-autofac/)
 - [Dave's blog](http://buksbaum.us/)
 
+__Version 1.4.2 - 2012/11/18__
+  * Updated Caliburn.Micro to 1.4
+
 __Version 1.4.1 - 2012/05/21__
   * Merged Windows Phone 7.1 fixes from distantcam (https://github.com/distantcam/Caliburn.Micro.Autofac)
 

--- a/src/Caliburn.Micro.Autofac-NET4/AutofacBootstrapper.cs
+++ b/src/Caliburn.Micro.Autofac-NET4/AutofacBootstrapper.cs
@@ -41,6 +41,9 @@ namespace Caliburn.Micro.Autofac
     public Func<IEventAggregator> CreateEventAggregator { get; set; }
     #endregion
 
+    public AutofacBootstrapper(bool useApplication = true) : base(useApplication) {
+    } 
+
     /// <summary>
     /// Do not override this method. This is where the IoC container is configured.
     /// <remarks>

--- a/src/Caliburn.Micro.Autofac-NET4/Caliburn.Micro.Autofac-NET4.csproj
+++ b/src/Caliburn.Micro.Autofac-NET4/Caliburn.Micro.Autofac-NET4.csproj
@@ -41,9 +41,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Autofac.2.6.1.841\lib\NET40\Autofac.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Caliburn.Micro, Version=1.3.1.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
+    <Reference Include="Caliburn.Micro, Version=1.4.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\net40\Caliburn.Micro.dll</HintPath>
+      <HintPath>..\..\packages\Caliburn.Micro.1.4\lib\net40\Caliburn.Micro.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
@@ -51,7 +51,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\net40\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>..\..\packages\Caliburn.Micro.1.4\lib\net40\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -71,7 +71,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y $(TargetDir)$(TargetFileName) $(SolutionDir)lib\net40\</PostBuildEvent>
+    <PostBuildEvent>xcopy /Y "$(TargetDir)$(TargetFileName)" "$(SolutionDir)lib\net40\"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Caliburn.Micro.Autofac-NET4/packages.config
+++ b/src/Caliburn.Micro.Autofac-NET4/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.6.1.841" />
-  <package id="Caliburn.Micro" version="1.3.1" />
+  <package id="Caliburn.Micro" version="1.4" targetFramework="net40" />
 </packages>

--- a/src/Caliburn.Micro.Autofac-SL4/Caliburn.Micro.Autofac-SL4.csproj
+++ b/src/Caliburn.Micro.Autofac-SL4/Caliburn.Micro.Autofac-SL4.csproj
@@ -52,9 +52,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Autofac.2.6.1.841\lib\SL4\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Caliburn.Micro, Version=1.3.1.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\sl4\Caliburn.Micro.dll</HintPath>
+    <Reference Include="Caliburn.Micro">
+      <HintPath>..\..\packages\Caliburn.Micro.1.4\lib\sl4\Caliburn.Micro.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System.ComponentModel.Composition, Version=2.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
@@ -64,10 +63,10 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Windows.Controls, Version=2.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\sl4\System.Windows.Controls.dll</HintPath>
+      <HintPath>..\..\packages\Caliburn.Micro.1.4\lib\sl4\System.Windows.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="System.Windows.Interactivity, Version=4.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\sl4\System.Windows.Interactivity.dll</HintPath>
+    <Reference Include="System.Windows.Interactivity">
+      <HintPath>..\..\packages\Caliburn.Micro.1.4\lib\sl4\System.Windows.Interactivity.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -97,7 +96,7 @@
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y $(TargetDir)$(TargetFileName) $(SolutionDir)lib\SL4\</PostBuildEvent>
+    <PostBuildEvent>xcopy /Y &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(SolutionDir)lib\SL4\&quot;</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Caliburn.Micro.Autofac-SL4/packages.config
+++ b/src/Caliburn.Micro.Autofac-SL4/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.6.1.841" />
-  <package id="Caliburn.Micro" version="1.3.1" />
+  <package id="Caliburn.Micro" version="1.4" targetFramework="sl40" />
 </packages>

--- a/src/Caliburn.Micro.Autofac-WP7/Caliburn.Micro.Autofac-WP71.csproj
+++ b/src/Caliburn.Micro.Autofac-WP7/Caliburn.Micro.Autofac-WP71.csproj
@@ -47,21 +47,19 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Autofac.2.6.1.841\lib\SL4-WindowsPhone\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Caliburn.Micro, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\sl4-windowsphone71\Caliburn.Micro.dll</HintPath>
+    <Reference Include="Caliburn.Micro">
+      <HintPath>..\..\packages\Caliburn.Micro.1.4\lib\wp71\Caliburn.Micro.dll</HintPath>
     </Reference>
-    <Reference Include="Caliburn.Micro.Extensions, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\sl4-windowsphone71\Caliburn.Micro.Extensions.dll</HintPath>
+    <Reference Include="Caliburn.Micro.Extensions">
+      <HintPath>..\..\packages\Caliburn.Micro.1.4\lib\wp71\Caliburn.Micro.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Phone" />
     <Reference Include="Microsoft.Phone.Controls, Version=7.0.0.0, Culture=neutral, PublicKeyToken=24eec0d8c86cda1e, processorArchitecture=MSIL" />
     <Reference Include="System.Windows" />
     <Reference Include="system" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Windows.Interactivity, Version=3.8.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\sl4-windowsphone71\System.Windows.Interactivity.dll</HintPath>
+    <Reference Include="System.Windows.Interactivity">
+      <HintPath>..\..\packages\Caliburn.Micro.1.3.1\lib\wp71\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Net" />

--- a/src/Caliburn.Micro.Autofac-WP7/packages.config
+++ b/src/Caliburn.Micro.Autofac-WP7/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.6.1.841" />
-  <package id="Caliburn.Micro" version="1.3.1" />
+  <package id="Caliburn.Micro" version="1.4" targetFramework="wp71" />
 </packages>


### PR DESCRIPTION
Notes:
 
  1. Caliburn.Micro 1.4 is not binary compatible with 1.3.1 due to an optional useApplication constructor parameter in the Bootstrapper. That is the main reason to update.
  2. I don't have Windows Phone 7 SDK installed so I updated that csproj in Notepad and did not really test that.